### PR TITLE
Apple Silicon improvements

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,10 +6,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "e6a6c016b0663e06fa5fccf1cd8152eab8aa8180c583ec20c872f4f9953a7ac5",
+    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.1/rules_go-v0.22.1.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.22.1/rules_go-v0.22.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.tar.gz",
     ],
 )
 

--- a/rules.bzl
+++ b/rules.bzl
@@ -12,6 +12,15 @@ def _buildbuddy_toolchain_impl(rctx):
     relative_path_prefix = "external/%s/" % rctx.name
     toolchain_path_prefix = relative_path_prefix
 
+    # Select the correct default platform.
+    if rctx.os.name == "mac os x":
+        if rctx.os.arch == "aarch64":
+            default_platform = "platform_darwin_arm64"
+        else:
+            default_platform = "platform_darwin"
+    else:
+        default_platform = "platform_linux"
+
     substitutions = {
         "%{repo_name}": rctx.name,
         "%{llvm_version}": LLVM_VERSION,
@@ -28,9 +37,8 @@ def _buildbuddy_toolchain_impl(rctx):
         "%{default_cc_toolchain_suite}": "@local_config_cc//:toolchain" if rctx.os.name == "mac os x" else ":llvm_cc_toolchain_suite" if rctx.attr.llvm else ":ubuntu1604_cc_toolchain_suite",
         "%{default_cc_toolchain}": ":llvm_cc_toolchain" if rctx.attr.llvm else ":ubuntu1604_cc_toolchain",
         "%{default_docker_image}": rctx.attr.docker_image,
-        "%{default_platform}": "platform_darwin" if rctx.os.name == "mac os x" else "platform_linux",
+        "%{default_platform}": default_platform,
     }
-
     rctx.template(
         "cc_toolchain_config.bzl",
         Label("//templates:cc_toolchain_config.bzl.tpl"),

--- a/templates/BUILD.tpl
+++ b/templates/BUILD.tpl
@@ -40,6 +40,20 @@ platform(
     },
 )
 
+platform(
+    name = "platform_darwin_arm64",
+    constraint_values = [
+        "@bazel_tools//platforms:aarch64",
+        "@bazel_tools//platforms:osx",
+        "@bazel_tools//tools/cpp:clang",
+    ],
+    exec_properties = {
+        "OSFamily": "Darwin",
+        "Arch": "arm64",
+        "container-image": "none",
+    },
+)
+
 ## Java 8
 
 java_runtime(


### PR DESCRIPTION
This PR adds support for a darwin arm64 host. I ran into some issues in the go toolchain when trying to run a remote exec build from my Apple Silicon machine.

- I upgraded rules_go to a newer version (not sure if it mattered to fix my specific issue, but good to upgrade regardless).
- I added a new `platform_darwin_arm64` with `Arch=arm64`. This is now the default platform selected when running on Apple Silicon, otherwise everything should behave like before.