### PR TITLE
Fix incompatibilities with upcoming Bazel 6.x

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -38,6 +38,10 @@ def _buildbuddy_toolchain_impl(rctx):
         "%{default_cc_toolchain}": ":llvm_cc_toolchain" if rctx.attr.llvm else ":ubuntu1604_cc_toolchain",
         "%{default_docker_image}": rctx.attr.docker_image,
         "%{default_platform}": default_platform,
+        # Handle removal of JDK8_JVM_OPTS in bazel 6.0.0:
+        # https://github.com/bazelbuild/bazel/commit/3a0a4f3b6931fbb6303fc98eec63d4434d8aece4
+        "%{jvm_opts_import}": '"JDK8_JVM_OPTS",' if native.bazel_version < "6.0.0" else "",
+        "%{jvm_opts}": "JDK8_JVM_OPTS" if native.bazel_version < "6.0.0" else '["-Xbootclasspath/p:$(location @remote_java_tools//:javac_jar)"]',
     }
     rctx.template(
         "cc_toolchain_config.bzl",

--- a/templates/BUILD.tpl
+++ b/templates/BUILD.tpl
@@ -17,8 +17,8 @@ alias(
 platform(
     name = "platform_linux",
     constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
@@ -30,8 +30,8 @@ platform(
 platform(
     name = "platform_darwin",
     constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:osx",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:macos",
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
@@ -64,14 +64,14 @@ java_runtime(
 
 load(
     "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
-    "JDK8_JVM_OPTS",
+    %{jvm_opts_import}
     "default_java_toolchain",
     "java_runtime_files",
 )
 
 default_java_toolchain(
     name = "toolchain_jdk8",
-    jvm_opts = JDK8_JVM_OPTS,
+    jvm_opts = %{jvm_opts},
     source_version = "8",
     target_version = "8",
 )
@@ -102,13 +102,13 @@ cc_toolchain_suite(
 toolchain(
     name = "ubuntu1604_cc_toolchain",
     exec_compatible_with = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
         "@bazel_tools//tools/cpp:clang",
     ],
     target_compatible_with = [
         "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = ":ubuntu1604_local_cc_toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",


### PR DESCRIPTION
- `@bazel_tools//platforms` was soft-deprecated, but in Bazel 6.0.0 it's now hard-deprecated (results in a build error, saying to migrate to `@platforms`). It appears `@platforms` is supported at least as far back as 3.0.0, maybe earlier, so I figured it's probably not worth supporting earlier versions.
- `JDK8_JVM_OPTS` will be removed in Bazel 6.x. I replaced it with the latest flag value as of Bazel 5.3.1. Not exactly sure if this is the right approach, but it at least unbreaks the build that I tested in our BuildBuddy repo. Need to test with a Java action before submitting.