### PR TITLE
Add environment variable override for external_cc

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -14,7 +14,10 @@ def _buildbuddy_toolchain_impl(rctx):
 
     # Select the correct default platform.
     default_platform = "platform"
-    if rctx.attr.external_cc:
+    external_cc_override = rctx.os.environ.get("BUILDBUDDY_TOOLCHAIN_OVERRIDE_USE_EXTERNAL_CC", "")
+    if external_cc_override == "0":
+        pass
+    elif external_cc_override == "1" or rctx.attr.external_cc:
         default_platform += "_bare"
     if rctx.os.name == "mac os x":
         default_platform += "_darwin"
@@ -112,6 +115,7 @@ _buildbuddy_toolchain = repository_rule(
     },
     local = False,
     implementation = _buildbuddy_toolchain_impl,
+    environ = ["BUILDBUDDY_TOOLCHAIN_OVERRIDE_USE_EXTERNAL_CC"],
 )
 
 # Specifying an empty container_image value means "use the default image."


### PR DESCRIPTION
In order to be able to control this behavior via flags, we must support an environment variable override. At the stage where `repository_rule`s can be called, the workspace loading stage, you are not allowed to use `config_setting` or `select`, so even if the end user of this repo were to make a flag or a `build_setting` that depended on an environment variable, they still could not change the value of `external_cc` without directly modifying their `WORKSPACE` or an imported `.bzl` file.

To that end, we introduce the `BUILDBUDDY_TOOLCHAIN_OVERRIDE_USE_EXTERNAL_CC` environment variable. Set it to `1` to enable `external_cc`, or `0` to disable it. As the name suggests, if it exists, it will override any value passed into the repository rule.
