### PR TITLE
toolchain: allow to pass extra cxx_builtin_include_directories

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -65,6 +65,7 @@ def _buildbuddy_toolchain_impl(rctx):
         Label("//templates:Makevars.tpl"),
         substitutions,
     )
+    substitutions["%{extra_cxx_builtin_include_directories}"] = "\n".join(['%s"%s",' % (" " * 8, x) for x in rctx.attr.extra_cxx_builtin_include_directories])
     rctx.template(
         "BUILD",
         Label("//templates:BUILD.tpl"),
@@ -105,6 +106,7 @@ _buildbuddy_toolchain = repository_rule(
         "container_image": attr.string(),
         "java_version": attr.string(),
         "gcc_version": attr.string(),
+        "extra_cxx_builtin_include_directories": attr.string_list(),
     },
     local = False,
     implementation = _buildbuddy_toolchain_impl,
@@ -117,7 +119,7 @@ UBUNTU16_04_IMAGE = "gcr.io/flame-public/executor-docker-default:v1.6.0"
 
 UBUNTU20_04_IMAGE = "gcr.io/flame-public/rbe-ubuntu20-04:latest"
 
-def buildbuddy(name, container_image = "", llvm = False, java_version = "", gcc_version = ""):
+def buildbuddy(name, container_image = "", llvm = False, java_version = "", gcc_version = "", extra_cxx_builtin_include_directories = []):
     default_tool_versions = _default_tool_versions(container_image)
 
     _buildbuddy_toolchain(
@@ -126,6 +128,7 @@ def buildbuddy(name, container_image = "", llvm = False, java_version = "", gcc_
         llvm = llvm,
         java_version = java_version or default_tool_versions["java"],
         gcc_version = gcc_version or default_tool_versions["gcc"],
+        extra_cxx_builtin_include_directories = extra_cxx_builtin_include_directories,
     )
 
 def _default_tool_versions(container_image):

--- a/templates/BUILD.tpl
+++ b/templates/BUILD.tpl
@@ -150,6 +150,7 @@ cc_toolchain_config(
         "/usr/include/c++/%{gcc_version}",
         "/usr/include/x86_64-linux-gnu/c++/%{gcc_version}",
         "/usr/include/c++/%{gcc_version}/backward",
+        %{extra_cxx_builtin_include_directories}
     ],
     tool_paths = {"ar": "/usr/bin/ar",
         "ld": "/usr/bin/ld",


### PR DESCRIPTION
For CentOS we need to be able to inject extra cxx arguments, like
```
    extra_cxx_builtin_include_directories = [
        "/usr/lib/gcc/x86_64-redhat-linux/4.8.5/include/",
    ]
```