### PR TITLE
upkeep: update deps and deprecate java_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Bazel provides support for Java toolchains out of the box.
 You can enabled the Java toolchain with the following flags:
 
 ```
---java_language_version=11
---tool_java_language_version=11
---java_runtime_version=remotejdk_11
---tool_java_runtime_version=remotejdk_11
+--java_language_version=17
+--tool_java_language_version=17
+--java_runtime_version=remotejdk_17
+--tool_java_runtime_version=remotejdk_17
 ```
 
 Available verions are listed in [Bazel's User Manual](https://bazel.build/docs/user-manual#java-language-version)
@@ -122,7 +122,7 @@ adding the following exec_properties:
 
 - Check out our official documentation for [RBE Setup](https://www.buildbuddy.io/docs/rbe-setup)
 - For more advanced use cases, check out Bazel's [bazel-toolchains repo](https://github.com/bazelbuild/bazel-toolchains) and the [docs on configuring C++ toolchains](https://docs.bazel.build/versions/master/tutorial/cc-toolchain-config.html).
-- Many thanks to the team at Grail who's [LLVM toolchain repo](https://github.com/bazel-contrib/toolchains_llvm) served as the basis for this repo.
+- Many thanks to the maintainers of [LLVM toolchain repo](https://github.com/bazel-contrib/toolchains_llvm), which served as the basis for this repo.
 - Major props to the team at VSCO who's [toolchain repo](https://github.com/vsco/bazel-toolchains) paved the way for using LLVM as a Bazel toolchain.
 
 ## Other CC toolchains

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # BuildBuddy RBE Toolchain
 
-Currently supports Linux C/C++ (including CGO) & Java builds on Ubuntu 16.04
-or Ubuntu 20.04 (**experimental**).
+Currently supports Linux C/C++ (including CGO) & Java builds on Ubuntu 16.04 or Ubuntu 20.04.
 
 ## Usage instructions
 
@@ -37,13 +36,19 @@ bazel build server \
 
 ## Java support
 
-If you need Java support, you just need to add a few more flags:
+Bazel provides support for Java toolchains out of the box.
+You can enabled the Java toolchain with the following flags:
 
 ```
---javabase=@buildbuddy_toolchain//:javabase
---host_javabase=@buildbuddy_toolchain//:javabase
---java_toolchain=@buildbuddy_toolchain//:java_toolchain
+--java_language_version=11
+--tool_java_language_version=11
+--java_runtime_version=remotejdk_11
+--tool_java_runtime_version=remotejdk_11
 ```
+
+Available verions ar listed in [Bazel's User Manual](https://bazel.build/docs/user-manual#java-language-version)
+
+If you need a custom Java toolchain, see Bazel's docs on [Java toolchain configuration](https://bazel.build/docs/bazel-and-java#config-java-toolchains).
 
 ## GCC / Clang selection
 
@@ -79,7 +84,7 @@ This image includes the following build tools:
 - Python 3.6.10
 - Go 1.14.1
 
-### Ubuntu 20.04 image (**experimental**)
+### Ubuntu 20.04 image
 
 To use Ubuntu 20.04, import the toolchain as follows:
 
@@ -115,6 +120,23 @@ adding the following exec_properties:
 
 ## Additional resources
 
+- Check out our official documentation for [RBE Setup](https://www.buildbuddy.io/docs/rbe-setup)
 - For more advanced use cases, check out Bazel's [bazel-toolchains repo](https://github.com/bazelbuild/bazel-toolchains) and the [docs on configuring C++ toolchains](https://docs.bazel.build/versions/master/tutorial/cc-toolchain-config.html).
-- Many thanks to the team at Grail who's [LLVM toolchain repo](https://github.com/grailbio/bazel-toolchain) served as the basis for this repo.
+- Many thanks to the team at Grail who's [LLVM toolchain repo](https://github.com/bazel-contrib/toolchains_llvm) served as the basis for this repo.
 - Major props to the team at VSCO who's [toolchain repo](https://github.com/vsco/bazel-toolchains) paved the way for using LLVM as a Bazel toolchain.
+
+## Other CC toolchains
+
+For advance users who want to write your own CC toolchain, here are some existing CC toolchains that you could use as reference:
+
+- Bazel's [default local CC toolchains](https://cs.opensource.google/bazel/bazel/+/master:tools/cpp/;drc=bd2da6e977172398bb6612c3a45e91fd1192961a)
+
+- Uber's [Zig-based CC Toolchain](https://github.com/uber/hermetic_cc_toolchain/)
+
+- [LLVM toolchain](https://github.com/bazel-contrib/toolchains_llvm)
+
+- [MUSL toolchain](https://github.com/bazel-contrib/musl-toolchain)
+
+- [GCC toolchain](https://github.com/f0rmiga/gcc-toolchain)
+
+- Apple_support's [XCode toolchain](https://github.com/bazelbuild/apple_support/blob/a40bcaa218ee423168dd3f9af8085e6bacac2f9f/crosstool/cc_toolchain_config.bzl#L14)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can enabled the Java toolchain with the following flags:
 --tool_java_runtime_version=remotejdk_11
 ```
 
-Available verions ar listed in [Bazel's User Manual](https://bazel.build/docs/user-manual#java-language-version)
+Available verions are listed in [Bazel's User Manual](https://bazel.build/docs/user-manual#java-language-version)
 
 If you need a custom Java toolchain, see Bazel's docs on [Java toolchain configuration](https://bazel.build/docs/bazel-and-java#config-java-toolchains).
 
@@ -127,7 +127,7 @@ adding the following exec_properties:
 
 ## Other CC toolchains
 
-For advance users who want to write your own CC toolchain, here are some existing CC toolchains that you could use as reference:
+For advanced users who want to write their own CC toolchain, these existing CC toolchains that can serve as references:
 
 - Bazel's [default local CC toolchains](https://cs.opensource.google/bazel/bazel/+/master:tools/cpp/;drc=bd2da6e977172398bb6612c3a45e91fd1192961a)
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,5 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_cc",
     sha256 = "d75a040c32954da0d308d3f2ea2ba735490f49b3a7aa3e4b40259ca4b814f825",
-    # strip_prefix = "rules_cc-0.0.10-rc1",
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.10-rc1/rules_cc-0.0.10-rc1.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,16 +5,8 @@ workspace(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.tar.gz",
-    ],
+    name = "rules_cc",
+    sha256 = "d75a040c32954da0d308d3f2ea2ba735490f49b3a7aa3e4b40259ca4b814f825",
+    # strip_prefix = "rules_cc-0.0.10-rc1",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.10-rc1/rules_cc-0.0.10-rc1.tar.gz"],
 )
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()

--- a/rules.bzl
+++ b/rules.bzl
@@ -121,6 +121,11 @@ UBUNTU16_04_IMAGE = "gcr.io/flame-public/executor-docker-default:enterprise-v1.6
 UBUNTU20_04_IMAGE = "gcr.io/flame-public/rbe-ubuntu20-04:latest"
 
 def buildbuddy(name, container_image = "", llvm = False, java_version = "", gcc_version = "", extra_cxx_builtin_include_directories = []):
+    if java_version != "":
+        print("""
+WARNING: java_version support in buildBuddy_toolchain is deprecated and will be removed in a future release.
+Please visit https://www.buildbuddy.io/docs/rbe-setup#java-toolchain for the recommended Java toolchain setup.""")
+
     default_tool_versions = _default_tool_versions(container_image)
 
     _buildbuddy_toolchain(

--- a/rules.bzl
+++ b/rules.bzl
@@ -123,7 +123,7 @@ UBUNTU20_04_IMAGE = "gcr.io/flame-public/rbe-ubuntu20-04:latest"
 def buildbuddy(name, container_image = "", llvm = False, java_version = "", gcc_version = "", extra_cxx_builtin_include_directories = []):
     if java_version != "":
         print("""
-WARNING: java_version support in buildBuddy_toolchain is deprecated and will be removed in a future release.
+WARNING: java_version support in buildbuddy-toolchain is deprecated and will be removed in a future release.
 Please visit https://www.buildbuddy.io/docs/rbe-setup#java-toolchain for the recommended Java toolchain setup.""")
 
     default_tool_versions = _default_tool_versions(container_image)


### PR DESCRIPTION
Remove rules_go as a dependency.
Add rules_cc latest release.

Update documentation to remove 20.04 as experimental.

Replace the documentation for BuildBuddy's Java toolchain with Bazel's
remotejdk_X toolchains.

Mark specifically setting "java_version" as deprecated.
