### PR TITLE
Provide examples for using buildbuddy-toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ bazel-*
 node_modules
 
 MODULE.bazel*
+
+user.bazelrc

--- a/examples/workspace/.bazelrc
+++ b/examples/workspace/.bazelrc
@@ -1,0 +1,46 @@
+# A bzlmod example will be provided separately
+common --noenable_bzlmod
+
+
+# Use a minimal set of environment variables for action execution to improve
+# build hermeticity and remote cache hits.
+common --incompatible_strict_action_env
+
+
+# Enable BuildBuddy build event service
+common --bes_results_url=https://app.buildbuddy.io/invocation/
+common --bes_backend=grpcs://remote.buildbuddy.io
+# Enable BuildBuddy Remote Execution
+common:remote --remote_timeout=3600
+common:remote --remote_executor=grpcs://remote.buildbuddy.io
+
+
+# Target Linux platform when build remotely
+#
+# Usage:
+#
+#   $ bazel build --config=remote-linux //...
+#
+common:remote-linux --config=remote
+common:remote-linux --platforms=@buildbuddy_toolchain//:platform_linux
+# Register "execution platforms" and "cc toolchains" using Bazel flag.
+#
+# These could also be defined statically in WORKSPACE files
+# using `register_execution_platforms` and `register_toolchains` global
+# starlark functions.
+#
+# Use flag `--toolchain_resolution_debug=cpp` to troubleshoot Bazel's toolchain
+# resolution and selection.
+#
+# References:
+#   - https://bazel.build/rules/lib/globals/workspace#register_execution_platforms
+#   - https://bazel.build/rules/lib/globals/workspace#register_toolchains
+common:remote-linux --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux
+common:remote-linux --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
+
+
+# Separate file to keep API Key that should have the follow flag
+#
+#   common --remote_header=x-buildbuddy-api-key=********
+#
+try-import %workspace%/user.bazelrc

--- a/examples/workspace/.gitignore
+++ b/examples/workspace/.gitignore
@@ -1,0 +1,1 @@
+user.bazelrc

--- a/examples/workspace/BUILD
+++ b/examples/workspace/BUILD
@@ -1,0 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cc"],
+)

--- a/examples/workspace/WORKSPACE
+++ b/examples/workspace/WORKSPACE
@@ -1,0 +1,32 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# In real repo, this should be replaced with like this
+#
+#   http_archive(
+#       name = "io_buildbuddy_buildbuddy_toolchain",
+#       sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", # replace with actual value
+#       strip_prefix = "buildbuddy-toolchain-0000000000000000000000000000000000000000", # replace with actual commit hash
+#       urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/0000000000000000000000000000000000000000.tar.gz"], # replace with actual commit hash
+#   )
+#
+#   load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
+#
+#   buildbuddy_deps()
+#
+#   load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+#
+#   buildbuddy(name = "buildbuddy_toolchain")
+#
+# for more information, see instructions in https://github.com/buildbuddy-io/buildbuddy-toolchain?tab=readme-ov-file#usage-instructions
+local_repository(
+    name = "io_buildbuddy_buildbuddy_toolchain",
+    path = "../../",
+)
+
+load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
+
+buildbuddy_deps()
+
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+
+buildbuddy(name = "buildbuddy_toolchain")

--- a/examples/workspace/main.cc
+++ b/examples/workspace/main.cc
@@ -1,0 +1,20 @@
+#include <ctime>
+#include <iostream>
+#include <string>
+
+std::string get_greet(const std::string &who) { return "Hello " + who; }
+
+void print_localtime() {
+  std::time_t result = std::time(nullptr);
+  std::cout << std::asctime(std::localtime(&result));
+}
+
+int main(int argc, char **argv) {
+  std::string who = "world";
+  if (argc > 1) {
+    who = argv[1];
+  }
+  std::cout << get_greet(who) << std::endl;
+  print_localtime();
+  return 0;
+}


### PR DESCRIPTION
Provide a basic example of using buildbuddy-toolchain, including `.bazelrc`.

As we iterate on the toolchain, we could use the example to validate the setup.