### PR TITLE
container image: set 20.04 as the default image

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -132,7 +132,7 @@ UBUNTU20_04_IMAGE = "gcr.io/flame-public/rbe-ubuntu20-04:latest"
 
 def buildbuddy(
         name,
-        container_image = "",
+        container_image = UBUNTU20_04_IMAGE,
         llvm = False,
         java_version = "",
         gcc_version = "",


### PR DESCRIPTION
This switch the default image when using BuildBuddy toolchain to 20.04.

Note that the default image BuildBuddy is using when the image is set to
empty string is still 16.04.
