### PR TITLE
Prepare for 0.0.1 release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,14 +11,14 @@ buildbuddy = use_extension("//:extensions.bzl", "buildbuddy")
 use_repo(buildbuddy, "buildbuddy_toolchain")
 
 register_toolchains(
-    "@buildbuddy_toolchain//:ubuntu_cc_toolchain",
-    "@buildbuddy_toolchain//:windows_msvc_cc_toolchain",
+    "//toolchains/cc:ubuntu_gcc",
+    "//toolchains/cc:windows_msvc",
 )
 
 register_execution_platforms(
-    "@buildbuddy_toolchain//:platform_linux_x86_64",
-    "@buildbuddy_toolchain//:platform_linux_arm64",
-    "@buildbuddy_toolchain//:platform_darwin",
-    "@buildbuddy_toolchain//:platform_darwin_arm64",
-    "@buildbuddy_toolchain//:platform_windows",
+    "//platforms:linux_x86_64",
+    "//platforms:linux_arm64",
+    "//platforms:darwin_x86_64",
+    "//platforms:darwin_arm64",
+    "//platforms:windows_x86_64",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,9 +16,5 @@ register_toolchains(
 )
 
 register_execution_platforms(
-    "//platforms:linux_x86_64",
-    "//platforms:linux_arm64",
-    "//platforms:darwin_x86_64",
-    "//platforms:darwin_arm64",
-    "//platforms:windows_x86_64",
+    "//platforms:all",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,8 +11,9 @@ buildbuddy = use_extension("//:extensions.bzl", "buildbuddy")
 use_repo(buildbuddy, "buildbuddy_toolchain")
 
 register_toolchains(
-    "//toolchains/cc:ubuntu_gcc",
-    "//toolchains/cc:windows_msvc",
+    "//toolchains/cc:ubuntu_gcc_x86_64",
+    "//toolchains/cc:ubuntu_gcc_arm64",
+    "//toolchains/cc:windows_msvc_x86_64",
 )
 
 register_execution_platforms(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,24 @@
 module(
-    name = "buildbuddy_toolchain",
-    version = "0.0.0",
+    name = "toolchains_buildbuddy",
+    version = "0.0.1",
     repo_name = "io_buildbuddy_buildbuddy_toolchain",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "platforms", version = "0.0.10")
+
+buildbuddy = use_extension("//:extensions.bzl", "buildbuddy")
+use_repo(buildbuddy, "buildbuddy_toolchain")
+
+register_toolchains(
+    "@buildbuddy_toolchain//:ubuntu_cc_toolchain",
+    "@buildbuddy_toolchain//:windows_msvc_cc_toolchain",
+)
+
+register_execution_platforms(
+    "@buildbuddy_toolchain//:platform_linux_x86_64",
+    "@buildbuddy_toolchain//:platform_linux_arm64",
+    "@buildbuddy_toolchain//:platform_darwin",
+    "@buildbuddy_toolchain//:platform_darwin_arm64",
+    "@buildbuddy_toolchain//:platform_windows",
+)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ Currently supports Linux C/C++ (including CGO) & Java builds on Ubuntu 16.04 or 
 
 ## Usage instructions
 
+#### BzlMod
+
+Add the following to your `MODULE.bazel` file:
+
+```python
+bazel_dep(name = "buildbuddy_toolchain", repo_name = "buildbuddy")
+archive_override(
+    module_name = "buildbuddy_toolchain",
+    ...
+)
+
+buildbuddy = use_extension("@buildbuddy//:extensions.bzl", "buildbuddy")
+use_repo(buildbuddy, "buildbuddy_toolchain")
+```
+
+For a more detailed example and customization options, see our [example bzlmod workspace](https://github.com/buildbuddy-io/buildbuddy-toolchain/tree/master/examples/bzlmod).
+
+#### WORKSPACE
+
 Add the following lines to your `WORKSPACE` file. You'll probably want to pin your version to a specific commit rather than master.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Currently supports Linux C/C++ (including CGO) & Java builds on Ubuntu 16.04 or 
 
 ## Usage instructions
 
+For the most up-to-date instructions, see our [Official Documentation](https://buildbuddy.io/docs/rbe-setup).
+
 #### BzlMod
 
 Add the following to your `MODULE.bazel` file:
@@ -19,7 +21,7 @@ buildbuddy = use_extension("@buildbuddy//:extensions.bzl", "buildbuddy")
 use_repo(buildbuddy, "buildbuddy_toolchain")
 ```
 
-For a more detailed example and customization options, see our [example bzlmod workspace](https://github.com/buildbuddy-io/buildbuddy-toolchain/tree/master/examples/bzlmod).
+For a more detailed example and customization options, see our [BzlMod Example](https://github.com/buildbuddy-io/buildbuddy-toolchain/tree/master/examples/bzlmod).
 
 #### WORKSPACE
 
@@ -47,10 +49,9 @@ Now you can use the toolchain in your BuildBuddy RBE builds. For example:
 ```
 bazel build server \
     --remote_executor=remote.buildbuddy.io \
-    --extra_execution_platforms=@buildbuddy_toolchain//:platform \
-    --host_platform=@buildbuddy_toolchain//:platform \
-    --platforms=@buildbuddy_toolchain//:platform \
-    --crosstool_top=@buildbuddy_toolchain//:toolchain
+    --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain \
+    --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_x86_64 \
+    --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
 ```
 
 ## Java support

--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ For the most up-to-date instructions, see our [Official Documentation](https://b
 Add the following to your `MODULE.bazel` file:
 
 ```python
-bazel_dep(name = "buildbuddy_toolchain", repo_name = "buildbuddy")
-archive_override(
-    module_name = "buildbuddy_toolchain",
-    ...
-)
+bazel_dep(name = "toolchains_buildbuddy")
 
 buildbuddy = use_extension("@buildbuddy//:extensions.bzl", "buildbuddy")
+
 use_repo(buildbuddy, "buildbuddy_toolchain")
 ```
+
+The execution platforms and CC toolchains should be registered automatically under BzlMod.
 
 For a more detailed example and customization options, see our [BzlMod Example](https://github.com/buildbuddy-io/buildbuddy-toolchain/tree/master/examples/bzlmod).
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Add the following to your `MODULE.bazel` file:
 ```python
 bazel_dep(name = "toolchains_buildbuddy")
 
+# Use the extension to create toolchain and platform targets
 buildbuddy = use_extension("@buildbuddy//:extensions.bzl", "buildbuddy")
-
-use_repo(buildbuddy, "buildbuddy_toolchain")
 ```
 
 The execution platforms and CC toolchains should be registered automatically under BzlMod.

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -36,7 +36,7 @@ common:remote-linux --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 # toolchains and execution platforms. Examples:
 #
 #   common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
-#   common:remote-linux --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc
+#   common:remote-linux --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_x86_64
 #
 # Use flag `--toolchain_resolution_debug=cpp` to troubleshoot Bazel's toolchain
 # resolution and selection.

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -27,7 +27,7 @@ common:remote-linux --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
 
 ## Register "execution platforms" and "cc toolchains" using Bazel flag.
 #
-# Relevant toolchains and execution platforms are registered automatically inside @buildbuddy_toolchain//:MODULE.bazel file.
+# Relevant toolchains and execution platforms are registered automatically inside "toolchains_buildbuddy" module's MODULE.bazel file.
 # User could also register custom toolchains and execution platforms in their MODULE.bazel file using
 # `register_execution_platforms` and `register_toolchains` global starlark functions. These will take precedence over
 # the default ones.

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -22,7 +22,7 @@ common:remote --remote_executor=grpcs://remote.buildbuddy.io
 #   $ bazel build --config=remote-linux //...
 #
 common:remote-linux --config=remote
-common:remote-linux --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
+common:remote-linux --platforms=@toolchains_buildbuddy//platform:linux_x86_64
 
 
 ## Register "execution platforms" and "cc toolchains" using Bazel flag.
@@ -35,8 +35,8 @@ common:remote-linux --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
 # The flags `--extra_execution_platforms` and `--extra_toolchains` are used to override the staticcally registered 
 # toolchains and execution platforms. Examples:
 #
-#   common:remote-linux --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_x86_64
-#   common:remote-linux --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
+#   common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platform:linux_x86_64
+#   common:remote-linux --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc
 #
 # Use flag `--toolchain_resolution_debug=cpp` to troubleshoot Bazel's toolchain
 # resolution and selection.
@@ -54,7 +54,7 @@ common:remote-linux --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
 #   $ bazel build --config=remote-windows //...
 #
 common:remote-windows --config=remote
-common:remote-windows --platforms=@buildbuddy_toolchain//:platform_windows
+common:remote-windows --platforms=@toolchains_buildbuddy//platform:windows_x86_64
 
 
 # Separate file to keep API Key that should have the follow flag

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -15,7 +15,7 @@ common:remote --remote_timeout=3600
 common:remote --remote_executor=grpcs://remote.buildbuddy.io
 
 
-# Target Linux platform when build remotely
+## Target Linux platform when build remotely
 #
 # Usage:
 #
@@ -23,22 +23,31 @@ common:remote --remote_executor=grpcs://remote.buildbuddy.io
 #
 common:remote-linux --config=remote
 common:remote-linux --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
-# Register "execution platforms" and "cc toolchains" using Bazel flag.
+
+
+## Register "execution platforms" and "cc toolchains" using Bazel flag.
 #
-# These could also be defined statically in WORKSPACE files
-# using `register_execution_platforms` and `register_toolchains` global
-# starlark functions.
+# Relevant toolchains and execution platforms are registered automatically inside @buildbuddy_toolchain//:MODULE.bazel file.
+# User could also register custom toolchains and execution platforms in their MODULE.bazel file using
+# `register_execution_platforms` and `register_toolchains` global starlark functions. These will take precedence over
+# the default ones.
+#
+# The flags `--extra_execution_platforms` and `--extra_toolchains` are used to override the staticcally registered 
+# toolchains and execution platforms. Examples:
+#
+#   common:remote-linux --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_x86_64
+#   common:remote-linux --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
 #
 # Use flag `--toolchain_resolution_debug=cpp` to troubleshoot Bazel's toolchain
 # resolution and selection.
 #
 # References:
+#   - https://bazel.build/external/migration#register-toolchains
 #   - https://bazel.build/rules/lib/globals/workspace#register_execution_platforms
 #   - https://bazel.build/rules/lib/globals/workspace#register_toolchains
-common:remote-linux --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_x86_64
-common:remote-linux --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
 
-# Target Linux platform when build remotely
+
+## Target Windows platform when build remotely
 #
 # Usage:
 #
@@ -46,8 +55,7 @@ common:remote-linux --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolcha
 #
 common:remote-windows --config=remote
 common:remote-windows --platforms=@buildbuddy_toolchain//:platform_windows
-common:remote-windows --extra_execution_platforms=@buildbuddy_toolchain//:platform_windows
-common:remote-windows --extra_toolchains=@buildbuddy_toolchain//:windows_msvc_cc_toolchain
+
 
 # Separate file to keep API Key that should have the follow flag
 #

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -22,7 +22,7 @@ common:remote --remote_executor=grpcs://remote.buildbuddy.io
 #   $ bazel build --config=remote-linux //...
 #
 common:remote-linux --config=remote
-common:remote-linux --platforms=@toolchains_buildbuddy//platform:linux_x86_64
+common:remote-linux --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 
 
 ## Register "execution platforms" and "cc toolchains" using Bazel flag.
@@ -35,7 +35,7 @@ common:remote-linux --platforms=@toolchains_buildbuddy//platform:linux_x86_64
 # The flags `--extra_execution_platforms` and `--extra_toolchains` are used to override the staticcally registered 
 # toolchains and execution platforms. Examples:
 #
-#   common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platform:linux_x86_64
+#   common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 #   common:remote-linux --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc
 #
 # Use flag `--toolchain_resolution_debug=cpp` to troubleshoot Bazel's toolchain
@@ -54,7 +54,7 @@ common:remote-linux --platforms=@toolchains_buildbuddy//platform:linux_x86_64
 #   $ bazel build --config=remote-windows //...
 #
 common:remote-windows --config=remote
-common:remote-windows --platforms=@toolchains_buildbuddy//platform:windows_x86_64
+common:remote-windows --platforms=@toolchains_buildbuddy//platforms:windows_x86_64
 
 
 # Separate file to keep API Key that should have the follow flag

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -35,4 +35,7 @@ buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbudd
 #     )
 
 # All relevant toolchain and platform targets should be available under "@buildbuddy_toolchain//..." repository
+#
+# For convenience, the platform and toolchain targets are also "alias" in the module under
+# "@toolchains_buildbuddy//platforms:all" and "@toolchains_buildbuddy//toolchains/cc:all" packages.
 use_repo(buildbuddy, "buildbuddy_toolchain")

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -1,11 +1,14 @@
 module(name = "example")
 
+# "@toolchains_buildbuddy" is the module in the Bazel registry
 bazel_dep(name = "toolchains_buildbuddy")
 local_path_override(
     module_name = "toolchains_buildbuddy",
     path = "../../",
 )
 
+# The module provides an extension named "buildbuddy".
+# The extension creates a repository named "@buildbuddy_toolchain".
 buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbuddy")
 
 # Example customizations (all optional):

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -42,4 +42,6 @@ buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbudd
 #
 # User SHOULD prefer using these "@toolchains_buildbuddy//" Module's targets, over the repository targets
 # to avoid any breaking changes in the future.
-use_repo(buildbuddy, "buildbuddy_toolchain")
+#
+# (Optional) Use the repository directly instead.
+# use_repo(buildbuddy, "buildbuddy_toolchain")

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -1,12 +1,12 @@
 module(name = "example")
 
-bazel_dep(name = "buildbuddy_toolchain", repo_name = "buildbuddy")
+bazel_dep(name = "toolchains_buildbuddy")
 local_path_override(
-    module_name = "buildbuddy_toolchain",
+    module_name = "toolchains_buildbuddy",
     path = "../../",
 )
 
-buildbuddy = use_extension("@buildbuddy//:extensions.bzl", "buildbuddy")
+buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbuddy")
 
 # Example customizations (all optional):
 #

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -36,6 +36,10 @@ buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbudd
 
 # All relevant toolchain and platform targets should be available under "@buildbuddy_toolchain//..." repository
 #
-# For convenience, the platform and toolchain targets are also "alias" in the module under
-# "@toolchains_buildbuddy//platforms:all" and "@toolchains_buildbuddy//toolchains/cc:all" packages.
+# For convenience, the platform and toolchain targets are also "alias"ed under these packages inside the module:
+#   - @toolchains_buildbuddy//platforms/
+#   - @toolchains_buildbuddy//toolchains/cc/
+#
+# User SHOULD prefer using these "@toolchains_buildbuddy//" Module's targets, over the repository targets
+# to avoid any breaking changes in the future.
 use_repo(buildbuddy, "buildbuddy_toolchain")

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,0 +1,24 @@
+alias(
+    name = "linux_x86_64",
+    actual = "@buildbuddy_toolchain//:platform_linux_x86_64"
+)
+
+alias(
+    name = "linux_arm64",
+    actual = "@buildbuddy_toolchain//:platform_linux_arm64"
+)
+
+alias(
+    name = "darwin_x86_64",
+    actual = "@buildbuddy_toolchain//:platform_darwin"
+)
+
+alias(
+    name = "darwin_arm64",
+    actual = "@buildbuddy_toolchain//:platform_darwin_arm64"
+)
+
+alias(
+    name = "windows_x86_64",
+    actual = "@buildbuddy_toolchain//:platform_windows"
+)

--- a/templates/BUILD.tpl
+++ b/templates/BUILD.tpl
@@ -158,9 +158,26 @@ toolchain(
     name = "ubuntu_cc_toolchain",
     exec_compatible_with = [
         "@bazel_tools//tools/cpp:gcc",
+        "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
     target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    toolchain = ":ubuntu_local_cc_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "ubuntu_cc_toolchain_arm64",
+    exec_compatible_with = [
+        "@bazel_tools//tools/cpp:gcc",
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
         "@platforms//os:linux",
     ],
     toolchain = ":ubuntu_local_cc_toolchain",

--- a/toolchains/cc/BUILD
+++ b/toolchains/cc/BUILD
@@ -1,9 +1,14 @@
 alias(
-    name = "ubuntu_gcc",
+    name = "ubuntu_gcc_x86_64",
     actual = "@buildbuddy_toolchain//:ubuntu_cc_toolchain"
 )
 
 alias(
-    name = "windows_msvc",
+    name = "ubuntu_gcc_arm64",
+    actual = "@buildbuddy_toolchain//:ubuntu_cc_toolchain"
+)
+
+alias(
+    name = "windows_msvc_x86_64",
     actual = "@buildbuddy_toolchain//:windows_msvc_cc_toolchain"
 )

--- a/toolchains/cc/BUILD
+++ b/toolchains/cc/BUILD
@@ -1,0 +1,9 @@
+alias(
+    name = "ubuntu_gcc",
+    actual = "@buildbuddy_toolchain//:ubuntu_cc_toolchain"
+)
+
+alias(
+    name = "windows_msvc",
+    actual = "@buildbuddy_toolchain//:windows_msvc_cc_toolchain"
+)


### PR DESCRIPTION
In BzlMod, we have a top level module named `toolchains_buildbuddy`,
which contains the `buildbuddy` extension.
The extension will then be used to create the `buildbuddy_toolchain`
repository, which contains our toolchain and platform defintions.

Add automatic toolchains and exec platforms registration in the
MODULE.bazel of the `buildbuddy_toolchain` module. This means that any
repository which use our module would immediately get the relevant
toolchains and exec platforms available to them.

Fix documentations and comments in README.md and bzlmod examples.
