### PR TITLE
    bzlmod: drop exec platforms registration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,3 @@ register_toolchains(
     "//toolchains/cc:ubuntu_gcc_arm64",
     "//toolchains/cc:windows_msvc_x86_64",
 )
-
-register_execution_platforms(
-    "//platforms:all",
-)

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -36,8 +36,8 @@ common:remote --remote_executor=grpcs://remote.buildbuddy.io
 #
 # References:
 #   - https://bazel.build/external/migration#register-toolchains
-#   - https://bazel.build/rules/lib/globals/workspace#register_execution_platforms
-#   - https://bazel.build/rules/lib/globals/workspace#register_toolchains
+#   - https://bazel.build/rules/lib/globals/module#register_execution_platforms
+#   - https://bazel.build/rules/lib/globals/module#register_toolchains
 
 
 ## Target Linux platform when build remotely

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -15,25 +15,18 @@ common:remote --remote_timeout=3600
 common:remote --remote_executor=grpcs://remote.buildbuddy.io
 
 
-## Target Linux platform when build remotely
-#
-# Usage:
-#
-#   $ bazel build --config=remote-linux //...
-#
-common:remote-linux --config=remote
-common:remote-linux --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
-
-
 ## Register "execution platforms" and "cc toolchains" using Bazel flag.
 #
-# Relevant toolchains and execution platforms are registered automatically inside "toolchains_buildbuddy" module's MODULE.bazel file.
-# User could also register custom toolchains and execution platforms in their MODULE.bazel file using
-# `register_execution_platforms` and `register_toolchains` global starlark functions. These will take precedence over
-# the default ones.
+# Relevant toolchains are registered automatically inside "toolchains_buildbuddy" module's MODULE.bazel file.
+# Note that execution platforms are NOT registered automatically.
 #
-# The flags `--extra_execution_platforms` and `--extra_toolchains` are used to override the staticcally registered 
-# toolchains and execution platforms. Examples:
+# User can register custom toolchains and execution platforms in their MODULE.bazel file using
+# `register_execution_platforms` and `register_toolchains` global starlark functions.
+# These will take precedence over the default ones.
+#
+# The flags `--extra_execution_platforms` and `--extra_toolchains` are used to override the staticcally
+# registered toolchains and execution platforms.
+# For example:
 #
 #   common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 #   common:remote-linux --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_x86_64
@@ -47,6 +40,17 @@ common:remote-linux --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 #   - https://bazel.build/rules/lib/globals/workspace#register_toolchains
 
 
+## Target Linux platform when build remotely
+#
+# Usage:
+#
+#   $ bazel build --config=remote-linux //...
+#
+common:remote-linux --config=remote
+common:remote-linux --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
+common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
+
+
 ## Target Windows platform when build remotely
 #
 # Usage:
@@ -55,6 +59,7 @@ common:remote-linux --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 #
 common:remote-windows --config=remote
 common:remote-windows --platforms=@toolchains_buildbuddy//platforms:windows_x86_64
+common:remote-windows --extra_execution_platforms=@toolchains_buildbuddy//platforms:windows_x86_64
 
 
 # Separate file to keep API Key that should have the follow flag

--- a/examples/workspace/.bazelrc
+++ b/examples/workspace/.bazelrc
@@ -15,19 +15,18 @@ common:remote --remote_timeout=3600
 common:remote --remote_executor=grpcs://remote.buildbuddy.io
 
 
-# Target Linux platform when build remotely
+## Register "execution platforms" and "cc toolchains" using Bazel flag.
 #
-# Usage:
+# User can register custom toolchains and execution platforms in their WORKSPACE file using
+# `register_execution_platforms` and `register_toolchains` global starlark functions.
+# These will take precedence over the default ones.
 #
-#   $ bazel build --config=remote-linux //...
+# The flags `--extra_execution_platforms` and `--extra_toolchains` are used to override the staticcally
+# registered toolchains and execution platforms.
+# For example:
 #
-common:remote-linux --config=remote
-common:remote-linux --platforms=@buildbuddy_toolchain//:platform_linux
-# Register "execution platforms" and "cc toolchains" using Bazel flag.
-#
-# These could also be defined statically in WORKSPACE files
-# using `register_execution_platforms` and `register_toolchains` global
-# starlark functions.
+#   common:remote-linux --extra_execution_platforms=@buildbuddy_toolchain//:platforms_linux
+#   common:remote-linux --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
 #
 # Use flag `--toolchain_resolution_debug=cpp` to troubleshoot Bazel's toolchain
 # resolution and selection.
@@ -35,10 +34,21 @@ common:remote-linux --platforms=@buildbuddy_toolchain//:platform_linux
 # References:
 #   - https://bazel.build/rules/lib/globals/workspace#register_execution_platforms
 #   - https://bazel.build/rules/lib/globals/workspace#register_toolchains
+
+
+## Target Linux platform when build remotely
+#
+# Usage:
+#
+#   $ bazel build --config=remote-linux //...
+#
+common:remote-linux --config=remote
+common:remote-linux --platforms=@buildbuddy_toolchain//:platform_linux
 common:remote-linux --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux
 common:remote-linux --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
 
-# Target Linux platform when build remotely
+
+## Target Linux platform when build remotely
 #
 # Usage:
 #
@@ -48,6 +58,7 @@ common:remote-windows --config=remote
 common:remote-windows --platforms=@buildbuddy_toolchain//:platform_windows
 common:remote-windows --extra_execution_platforms=@buildbuddy_toolchain//:platform_windows
 common:remote-windows --extra_toolchains=@buildbuddy_toolchain//:windows_msvc_cc_toolchain
+
 
 # Separate file to keep API Key that should have the follow flag
 #


### PR DESCRIPTION


In theory, it should be possible to register multiple execution
platforms statically and let Bazel pick the correct one automatically.

In practice, there are a range of problems with this approach:

- Many rules have yet to switch to platform/toolchain setup, thus will
  be picking up the wrong tool.

- Many rules registered the wrong toolchains or registered them in the
  wrong order which caused cross-compilation to happen remotely. I.e. using
  an arm64 toolchain to compile an x86 stdlib.

- Users may need to switch between RBE and local exec with
  minimal flag changes.

Stop registering exec platforms automatically and advise users to set it
explicitly via a flag in `.bazelrc` file.
