### PR TITLE
bzlmod: use publish-to-bcr

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,20 @@
+{
+  "homepage": "https://github.com/buildbuddy-io/buildbuddy-toolchain",
+  "maintainers": [
+    {
+      "name": "Son Luong Ngoc",
+      "email": "son@buildbuddy.io",
+      "github": "sluongng"
+    },
+    {
+      "email": "fabian@meumertzhe.im",
+      "github": "fmeum",
+      "name": "Fabian Meumertzheim"
+    },
+  ],
+  "repository": [
+    "github:buildbuddy-io/buildbuddy-toolchain"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,14 @@
+# We recommend included a bcr test workspace that exercises your ruleset with bzlmod.
+# For an example, see https://github.com/aspect-build/bazel-lib/tree/main/e2e/bzlmod.
+bcr_test_module:
+  module_path: "examples/bzlmod"
+  matrix:
+    platform: ["ubuntu2004"]
+    bazel: [7.x]
+  tasks:
+    build_module:
+      name: "build module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}


### PR DESCRIPTION
Following the steps in
https://github.com/bazel-contrib/publish-to-bcr/tree/main?tab=readme-ov-file#how-it-works

so that we can automate our release to BCR.
