### PR TITLE
Fix arm64 toolchains for bzlmod

### DIFF
--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -50,6 +50,9 @@ common:remote-linux --config=remote
 common:remote-linux --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 
+common:remote-linux-arm64 --config=remote
+common:remote-linux-arm64 --platforms=@toolchains_buildbuddy//platforms:linux_arm64
+common:remote-linux-arm64 --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_arm64
 
 ## Target Windows platform when build remotely
 #

--- a/toolchains/cc/BUILD
+++ b/toolchains/cc/BUILD
@@ -5,7 +5,7 @@ alias(
 
 alias(
     name = "ubuntu_gcc_arm64",
-    actual = "@buildbuddy_toolchain//:ubuntu_cc_toolchain"
+    actual = "@buildbuddy_toolchain//:ubuntu_cc_toolchain_arm64"
 )
 
 alias(


### PR DESCRIPTION
Used the wrong toolchain in a previous PR.
