### PR TITLE
Remove Java support: fully remove java support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,6 @@ bazel build server \
     --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
 ```
 
-## Java support
-
-Bazel provides support for Java toolchains out of the box.
-You can enabled the Java toolchain with the following flags:
-
-```
---java_language_version=17
---tool_java_language_version=17
---java_runtime_version=remotejdk_17
---tool_java_runtime_version=remotejdk_17
-```
-
-Available verions are listed in [Bazel's User Manual](https://bazel.build/docs/user-manual#java-language-version)
-
-If you need a custom Java toolchain, see Bazel's docs on [Java toolchain configuration](https://bazel.build/docs/bazel-and-java#config-java-toolchains).
-
 ## Linux image variants
 
 The following Linux images are available for remote execution:
@@ -85,7 +69,6 @@ buildbuddy(name = "buildbuddy_toolchain", container_image = UBUNTU16_04_IMAGE)
 
 This image includes the following build tools:
 
-- Java 8 (javac 1.8.0_242)
 - GCC 5.4.0
 - GLIBC 2.23
 - Clang/LLVM 11.0.0
@@ -105,7 +88,6 @@ buildbuddy(name = "buildbuddy_toolchain", container_image = UBUNTU20_04_IMAGE)
 
 This image includes the following build tools:
 
-- Java 11.0.17
 - GCC 9.4.0
 - GLIBC 2.31
 - Clang/LLVM 15.0.0

--- a/rules.bzl
+++ b/rules.bzl
@@ -41,11 +41,6 @@ def _buildbuddy_toolchain_impl(rctx):
         "%{default_platform}": default_platform,
         "%{default_arch_constraint}": "aarch64" if rctx.os.arch == "aarch64" else "x86_64",
         "%{default_arch_exec_property}": "arm64" if rctx.os.arch == "aarch64" else "amd64",
-        "%{java_version}": rctx.attr.java_version or default_tool_versions["java"],
-        # Handle removal of JDK8_JVM_OPTS in bazel 6.0.0:
-        # https://github.com/bazelbuild/bazel/commit/3a0a4f3b6931fbb6303fc98eec63d4434d8aece4
-        "%{jvm_opts_import}": '"JDK8_JVM_OPTS",' if native.bazel_version and native.bazel_version < "6.0.0" and rctx.attr.java_version == "8" else "",
-        "%{jvm_opts}": "JDK8_JVM_OPTS" if native.bazel_version and native.bazel_version < "6.0.0" and rctx.attr.java_version == "8" else '["-Xbootclasspath/p:$(location @remote_java_tools//:javac_jar)"]',
         "%{msvc_edition}": rctx.attr.msvc_edition,
         "%{msvc_release}": rctx.attr.msvc_release,
         "%{msvc_version}": rctx.attr.msvc_version,
@@ -92,7 +87,6 @@ _buildbuddy_toolchain = repository_rule(
     attrs = {
         "llvm": attr.bool(),
         "container_image": attr.string(),
-        "java_version": attr.string(),
         "gcc_version": attr.string(),
         "msvc_edition": attr.string(values = ["Community", "Professional", "Enterprise"]),
         "msvc_release": attr.string(),
@@ -121,7 +115,6 @@ def buildbuddy(
         name,
         container_image = None,
         llvm = False,
-        java_version = "",
         gcc_version = "",
         msvc_edition = "Community",
         msvc_release = "2022",
@@ -129,16 +122,10 @@ def buildbuddy(
         windows_kits_release = "10",
         windows_kits_version = "10.0.22621.0",
         extra_cxx_builtin_include_directories = []):
-    if java_version != "":
-        print("""
-WARNING: java_version support in buildbuddy-toolchain is deprecated and will be removed in a future release.
-Please visit https://www.buildbuddy.io/docs/rbe-setup#java-toolchain for the recommended Java toolchain setup.""")
-
     _buildbuddy_toolchain(
         name = name,
         container_image = container_image,
         llvm = llvm,
-        java_version = java_version,
         gcc_version = gcc_version,
         msvc_edition = msvc_edition,
         msvc_release = msvc_release,
@@ -150,12 +137,12 @@ Please visit https://www.buildbuddy.io/docs/rbe-setup#java-toolchain for the rec
 
 def _default_tool_versions(container_image):
     if _is_same_repository(container_image, UBUNTU20_04_REPOSITORY):
-        return {"java": "11", "gcc": "9"}
+        return {"gcc": "9"}
 
     if _is_same_repository(container_image, UBUNTU22_04_REPOSITORY):
-        return {"java": "11", "gcc": "11"}
+        return {"gcc": "11"}
 
-    return {"java": "8", "gcc": "5"}
+    return {"gcc": "5"}
 
 def _is_same_repository(a, b):
     """Returns whether two repositories are the same (stripping tag or digest if necessary)."""

--- a/templates/BUILD.tpl
+++ b/templates/BUILD.tpl
@@ -1,9 +1,3 @@
-load(
-    "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
-    %{jvm_opts_import}
-    "default_java_toolchain",
-    "java_runtime_files",
-)
 load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 load(":windows_cc_toolchain_config.bzl", windows_cc_toolchain_config = "cc_toolchain_config")
@@ -104,21 +98,6 @@ platform(
     exec_properties = {
         "OSFamily": "Windows",
     },
-)
-
-## Java %{java_version}
-
-java_runtime(
-    name = "javabase",
-    srcs = [],
-    java_home = "/usr/lib/jvm/java-%{java_version}-openjdk-amd64",
-)
-
-default_java_toolchain(
-    name = "java_toolchain",
-    jvm_opts = %{jvm_opts},
-    source_version = "%{java_version}",
-    target_version = "%{java_version}",
 )
 
 ## Defaults


### PR DESCRIPTION
The deprecation notice has been out for a while and we do not offer any
Java support for BzlMod.

This PR will yank all Java references out of the repo.
Users should still be able to find relevant documents on our websites.
