### PR TITLE
platforms: annotate mac/windows platforms with self-hosted property

### DIFF
--- a/templates/BUILD.tpl
+++ b/templates/BUILD.tpl
@@ -76,8 +76,8 @@ platform(
     ],
     exec_properties = {
         "OSFamily": "Darwin",
-        "container-image": "none",
-        "dockerNetwork": "%{default_docker_network}",
+        "Arch": "amd64",
+        "use-self-hosted-executors": "true",
     },
 )
 
@@ -91,8 +91,7 @@ platform(
     exec_properties = {
         "OSFamily": "Darwin",
         "Arch": "arm64",
-        "container-image": "none",
-        "dockerNetwork": "%{default_docker_network}",
+        "use-self-hosted-executors": "true",
     },
 )
 
@@ -105,6 +104,7 @@ platform(
     ],
     exec_properties = {
         "OSFamily": "Windows",
+        "use-self-hosted-executors": "true",
     },
 )
 


### PR DESCRIPTION
We currently do not offer "shared" mac/windows executors.

All "managed" macos and windows executors are registered under the user's
organization and therefore, treated the same as self-hosted.

Remove irrelevant container/docker properties and add self-hosted property
to these platform definitions.
