### PR TITLE
examples/bzlmod: add docs for register_toolchains

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+examples

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,14 +4,12 @@ module(
     repo_name = "io_buildbuddy_buildbuddy_toolchain",
 )
 
-bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "platforms", version = "0.0.10")
 
 buildbuddy = use_extension("//:extensions.bzl", "buildbuddy")
 use_repo(buildbuddy, "buildbuddy_toolchain")
 
 register_toolchains(
-    "//toolchains/cc:ubuntu_gcc_x86_64",
-    "//toolchains/cc:ubuntu_gcc_arm64",
-    "//toolchains/cc:windows_msvc_x86_64",
+    "//toolchains/cc:all",
 )

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -46,4 +46,9 @@ buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbudd
 # to avoid any breaking changes in the future.
 #
 # (Optional) Use the repository directly instead.
-# use_repo(buildbuddy, "buildbuddy_toolchain")
+#     use_repo(buildbuddy, "buildbuddy_toolchain")
+#
+# (Optional) Register the toolchains.
+#     register_toolchains(
+#         "@toolchains_buildbuddy//toolchains/cc:all",
+#     )


### PR DESCRIPTION
Provide an example of register_toolchains.
Ignore examples directories when building from root.
Upgrade rules_cc to 0.0.17 to silent the warning.
