### PR TITLE
add --extra_toolchains flag to bzlmod example

### DIFF
--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -49,10 +49,12 @@ common:remote --remote_executor=grpcs://remote.buildbuddy.io
 common:remote-linux --config=remote
 common:remote-linux --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
+common:remote-linux --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_x86_64
 
 common:remote-linux-arm64 --config=remote
 common:remote-linux-arm64 --platforms=@toolchains_buildbuddy//platforms:linux_arm64
 common:remote-linux-arm64 --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_arm64
+common:remote-linux-arm64 --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_arm64
 
 ## Using custom Linux platform
 # 
@@ -70,6 +72,7 @@ common:custom-linux --extra_execution_platforms=//:my_linux_platform
 common:remote-windows --config=remote
 common:remote-windows --platforms=@toolchains_buildbuddy//platforms:windows_x86_64
 common:remote-windows --extra_execution_platforms=@toolchains_buildbuddy//platforms:windows_x86_64
+common:remote-windows --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:windows_msvc_x86_64
 
 
 # Separate file to keep API Key that should have the follow flag


### PR DESCRIPTION
To get `bazel build //:main --config=remote-linux` working for `examples/bzlmod`, I had to add the `--extra_toolchains` flag. I am on OS X building remotely on Linux.

(I would like to test builds with the toolchain in preparation for a release pipeline.)