### PR TITLE
example: ignore homerc and systemrc when running IT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
 
       - name: Run integration tests
         run: >-
+          bazel clean --expunge
+
+      - name: Run integration tests
+        run: >-
           bazel test //:all //examples:${{ matrix.test }}
           --bes_results_url=https://buildbuddy-toolchain.buildbuddy.io/invocation/
           --bes_backend=grpcs://buildbuddy-toolchain.buildbuddy.io
@@ -36,4 +40,5 @@ jobs:
           --remote_timeout=2m
           --remote_header=x-buildbuddy-api-key="${{ env.BUILDBUDDY_API_KEY }}"
           --test_output=all
+          --remote_instance_name=blah
           --enable_runfiles

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -6,6 +6,8 @@ load(
 )
 
 _BAZEL_STARTUP_OPTIONS = " ".join([
+    "--nohome_rc",
+    "--nosystem_rc",
 ])
 
 _BAZEL_BUILD_CMD = [

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -6,8 +6,8 @@ load(
 )
 
 _BAZEL_STARTUP_OPTIONS = " ".join([
-    "--nohome_rc",
-    # "--nosystem_rc",
+    # "--nohome_rc",
+    "--nosystem_rc",
 ])
 
 _BAZEL_BUILD_CMD = [

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -5,6 +5,11 @@ load(
     "default_test_runner",
 )
 
+_BAZEL_STARTUP_OPTIONS = " ".join([
+    "--nosystem_rc",
+    "--nohome_rc",
+])
+
 _BAZEL_BUILD_CMD = [
     "build",
     "//:main",
@@ -99,6 +104,7 @@ bazel_integration_test(
     timeout = "moderate",
     bazel_binaries = bazel_binaries,
     bazel_version = bazel_binaries.versions.current,
+    startup_options = _BAZEL_STARTUP_OPTIONS,
     test_runner = ":test_runner",
     workspace_files = [
         ":bzlmod_workspace_files",
@@ -116,6 +122,7 @@ bazel_integration_test(
     ],
     bazel_binaries = bazel_binaries,
     bazel_version = bazel_binaries.versions.current,
+    startup_options = _BAZEL_STARTUP_OPTIONS,
     tags = [],
     test_runner = ":rbe_test_runner",
     workspace_files = [
@@ -131,6 +138,7 @@ bazel_integration_test(
     timeout = "moderate",
     bazel_binaries = bazel_binaries,
     bazel_version = bazel_binaries.versions.current,
+    startup_options = _BAZEL_STARTUP_OPTIONS,
     test_runner = ":test_runner",
     workspace_files = [
         ":workspace_workspace_files",
@@ -148,6 +156,7 @@ bazel_integration_test(
     ],
     bazel_binaries = bazel_binaries,
     bazel_version = bazel_binaries.versions.current,
+    startup_options = _BAZEL_STARTUP_OPTIONS,
     tags = [],
     test_runner = ":workspace_rbe_test_runner",
     workspace_files = [

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -6,7 +6,6 @@ load(
 )
 
 _BAZEL_STARTUP_OPTIONS = " ".join([
-    "--nosystem_rc",
 ])
 
 _BAZEL_BUILD_CMD = [

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -7,7 +7,6 @@ load(
 
 _BAZEL_STARTUP_OPTIONS = " ".join([
     "--nosystem_rc",
-    "--nohome_rc",
 ])
 
 _BAZEL_BUILD_CMD = [

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -7,7 +7,7 @@ load(
 
 _BAZEL_STARTUP_OPTIONS = " ".join([
     "--nohome_rc",
-    "--nosystem_rc",
+    # "--nosystem_rc",
 ])
 
 _BAZEL_BUILD_CMD = [


### PR DESCRIPTION


Let's make sure the child bazel processes don't pick up config from the
homerc and systemrc if they are available.
