### PR TITLE
msvc: make env tmp configurable

### DIFF
--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -34,6 +34,7 @@ buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbudd
 #         msvc_version = "14.39.33519",
 #         windows_kits_release = "10",
 #         windows_kits_version = "10.0.22621.0",
+#         msvc_env_tmp = "C:\\Users\\User\\AppData\\Local\\Temp",
 #     )
 
 # All relevant toolchain and platform targets should be available under "@buildbuddy_toolchain//..." repository

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -50,13 +50,18 @@ def _ext_impl(mctx):
             "extra_cxx_builtin_include_directories": gcc_toolchain_tag.extra_cxx_builtin_include_directories,
         }
     if msvc_toolchain_tag:
-        macro_args |= {
-            "msvc_edition": msvc_toolchain_tag.msvc_edition,
-            "msvc_release": msvc_toolchain_tag.msvc_release,
-            "msvc_version": msvc_toolchain_tag.msvc_version,
-            "windows_kits_release": msvc_toolchain_tag.windows_kits_release,
-            "windows_kits_version": msvc_toolchain_tag.windows_kits_version,
-        }
+        if msvc_toolchain_tag.msvc_edition:
+            macro_args["msvc_edition"] = msvc_toolchain_tag.msvc_edition
+        if msvc_toolchain_tag.msvc_release:
+            macro_args["msvc_release"] = msvc_toolchain_tag.msvc_release
+        if msvc_toolchain_tag.msvc_version:
+            macro_args["msvc_version"] = msvc_toolchain_tag.msvc_version
+        if msvc_toolchain_tag.windows_kits_release:
+            macro_args["windows_kits_release"] = msvc_toolchain_tag.windows_kits_release
+        if msvc_toolchain_tag.windows_kits_version:
+            macro_args["windows_kits_version"] = msvc_toolchain_tag.windows_kits_version
+        if msvc_toolchain_tag.msvc_env_tmp:
+            macro_args["msvc_env_tmp"] = msvc_toolchain_tag.msvc_env_tmp
 
     bb_macro(
         name = "buildbuddy_toolchain",
@@ -79,6 +84,7 @@ buildbuddy = module_extension(
                 "msvc_version": attr.string(),
                 "windows_kits_release": attr.string(),
                 "windows_kits_version": attr.string(),
+                "msvc_env_tmp": attr.string(),
             },
         ),
         "platform": tag_class(

--- a/rules.bzl
+++ b/rules.bzl
@@ -63,6 +63,7 @@ def _buildbuddy_toolchain_impl(rctx):
         "%{msvc_version}": rctx.attr.msvc_version,
         "%{windows_kits_release}": rctx.attr.windows_kits_release,
         "%{windows_kits_version}": rctx.attr.windows_kits_version,
+        "%{msvc_env_tmp}": rctx.attr.msvc_env_tmp.replace("\\", "\\\\"),
     }
     rctx.template(
         "bin/cc_wrapper.sh",  # Co-located with the linker to help rules_go.
@@ -119,6 +120,7 @@ _buildbuddy_toolchain = repository_rule(
         "msvc_version": attr.string(),
         "windows_kits_release": attr.string(),
         "windows_kits_version": attr.string(),
+        "msvc_env_tmp": attr.string(),
         "extra_cxx_builtin_include_directories": attr.string_list(),
     },
     local = False,
@@ -151,6 +153,7 @@ def buildbuddy(
         msvc_version = "14.39.33519",
         windows_kits_release = "10",
         windows_kits_version = "10.0.22621.0",
+        msvc_env_tmp = "C:\\Users\\User\\AppData\\Local\\Temp",
         extra_cxx_builtin_include_directories = []):
     if java_version != "":
         # buildifier: disable=print
@@ -169,6 +172,7 @@ Please visit https://www.buildbuddy.io/docs/rbe-setup#java-toolchain for the rec
         msvc_version = msvc_version,
         windows_kits_release = windows_kits_release,
         windows_kits_version = windows_kits_version,
+        msvc_env_tmp = msvc_env_tmp,
         extra_cxx_builtin_include_directories = extra_cxx_builtin_include_directories,
     )
 

--- a/templates/BUILD.tpl
+++ b/templates/BUILD.tpl
@@ -8,7 +8,13 @@ load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 load("@rules_java//java/toolchains:java_runtime.bzl", "java_runtime")
 load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")
 load(":gcc_config.bzl", "GCC_BUILTIN_INCLUDE_PATHS")
-load(":msvc_config.bzl", "MSVC_BUILTIN_INCLUDE_PATHS")
+load(
+    ":msvc_config.bzl",
+    "MSVC_BUILTIN_INCLUDE_PATHS",
+    "MSVC_ENV_LIB_PATHS",
+    "MSVC_ENV_PATHS",
+    "MSVC_ENV_TMP",
+)
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 load(":windows_cc_toolchain_config.bzl", windows_cc_toolchain_config = "cc_toolchain_config")
 
@@ -292,34 +298,10 @@ windows_cc_toolchain_config(
     abi_version = "local",
     abi_libc_version = "local",
     toolchain_identifier = "msvc_toolchain_config",
-    msvc_env_tmp = "C:\\Users\\User\\AppData\\Local\\Temp",
-    msvc_env_path = ";".join([
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\Common7\\IDE\\",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\Common7\\IDE\\CommonExtensions\\Microsoft\\FSharp\\Tools",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\Common7\\IDE\\VC\\Linux\\bin\\ConnectionManagerExe",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\Common7\\IDE\\VC\\VCPackages",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\Common7\\Tools\\",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\MSBuild\\Current\\bin\\Roslyn",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\Team Tools\\DiagnosticsHub\\Collector",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\VC\\Tools\\MSVC\\%{msvc_version}\\bin\\HostX64\\x64",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\\\MSBuild\\Current\\Bin\\amd64",
-    ]),
-    msvc_env_include = ";".join([
-        "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\cppwinrt",
-        "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\shared",
-        "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\um",
-        "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\winrt",
-        "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\ucrt",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\VC\\Auxiliary\\VS\\include",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\VC\\Tools\\MSVC\\%{msvc_version}\\include",
-    ]),
-    msvc_env_lib = ";".join([
-        "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Lib\\%{windows_kits_version}\\um\\x64",
-        "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Lib\\%{windows_kits_version}\\ucrt\\x64",
-        "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\VC\\Tools\\MSVC\\%{msvc_version}\\lib\\x64",
-    ]),
+    msvc_env_tmp = MSVC_ENV_TMP,
+    msvc_env_path = ";".join(MSVC_ENV_PATHS),
+    msvc_env_include = ";".join(MSVC_BUILTIN_INCLUDE_PATHS),
+    msvc_env_lib = ";".join(MSVC_ENV_LIB_PATHS),
     msvc_cl_path = "C:/Program Files/Microsoft Visual Studio/%{msvc_release}/%{msvc_edition}/VC/Tools/MSVC/%{msvc_version}/bin/HostX64/x64/cl.exe",
     msvc_ml_path = "C:/Program Files/Microsoft Visual Studio/%{msvc_release}/%{msvc_edition}/VC/Tools/MSVC/%{msvc_version}/bin/HostX64/x64/ml64.exe",
     msvc_link_path = "C:/Program Files/Microsoft Visual Studio/%{msvc_release}/%{msvc_edition}/VC/Tools/MSVC/%{msvc_version}/bin/HostX64/x64/link.exe",

--- a/templates/msvc_config.bzl.tpl
+++ b/templates/msvc_config.bzl.tpl
@@ -1,10 +1,39 @@
+MSVC_ROOT = "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}"
+MSVC_TOOLS_ROOT = MSVC_ROOT + "\\VC\\Tools\\MSVC\\%{msvc_version}"
+
+WINDOWS_KITS_ROOT = "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}"
+WINDOWS_KITS_INCLUDE_ROOT = WINDOWS_KITS_ROOT + "\\Include\\%{windows_kits_version}"
+WINDOWS_KITS_LIB_ROOT = WINDOWS_KITS_ROOT + "\\Lib\\%{windows_kits_version}"
+
+MSVC_ENV_TMP = "%{msvc_env_tmp}"
+
+MSVC_ENV_PATHS = [
+    MSVC_ROOT + "\\Common7\\IDE\\",
+    MSVC_ROOT + "\\Common7\\IDE\\CommonExtensions\\Microsoft\\FSharp\\Tools",
+    MSVC_ROOT + "\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer",
+    MSVC_ROOT + "\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow",
+    MSVC_ROOT + "\\Common7\\IDE\\VC\\Linux\\bin\\ConnectionManagerExe",
+    MSVC_ROOT + "\\Common7\\IDE\\VC\\VCPackages",
+    MSVC_ROOT + "\\Common7\\Tools\\",
+    MSVC_ROOT + "\\MSBuild\\Current\\bin\\Roslyn",
+    MSVC_ROOT + "\\Team Tools\\DiagnosticsHub\\Collector",
+    MSVC_TOOLS_ROOT + "\\bin\\HostX64\\x64",
+    MSVC_ROOT + "\\MSBuild\\Current\\Bin\\amd64",
+]
+
 MSVC_BUILTIN_INCLUDE_PATHS = [
     # keep sorted
-    "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\cppwinrt",
-    "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\shared",
-    "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\ucrt",
-    "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\um",
-    "C:\\Program Files (x86)\\Windows Kits\\%{windows_kits_release}\\Include\\%{windows_kits_version}\\winrt",
-    "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\VC\\Auxiliary\\VS\\include",
-    "C:\\Program Files\\Microsoft Visual Studio\\%{msvc_release}\\%{msvc_edition}\\VC\\Tools\\MSVC\\%{msvc_version}\\include",
+    WINDOWS_KITS_INCLUDE_ROOT + "\\cppwinrt",
+    WINDOWS_KITS_INCLUDE_ROOT + "\\shared",
+    WINDOWS_KITS_INCLUDE_ROOT + "\\ucrt",
+    WINDOWS_KITS_INCLUDE_ROOT + "\\um",
+    WINDOWS_KITS_INCLUDE_ROOT + "\\winrt",
+    MSVC_ROOT + "\\VC\\Auxiliary\\VS\\include",
+    MSVC_TOOLS_ROOT + "\\include",
+]
+
+MSVC_ENV_LIB_PATHS = [
+    WINDOWS_KITS_LIB_ROOT + "\\um\\x64",
+    WINDOWS_KITS_LIB_ROOT + "\\ucrt\\x64",
+    MSVC_TOOLS_ROOT + "\\lib\\x64",
 ]


### PR DESCRIPTION
Expose msvc_env_tmp through both the WORKSPACE macro and the Bzlmod
buildbuddy.msvc_toolchain tag, then template it into msvc_config.bzl.

Only forward non-empty MSVC tag fields from the module extension.
Without this, buildbuddy.msvc_toolchain() could pass empty strings that
override defaults and trigger validation errors (for example
msvc_edition = "").

Move MSVC env path/include/lib defaults into msvc_config constants so
msvc_toolchain_config is less hard-coded and easier to maintain.

Signed-off-by: Son Luong Ngoc <sluongng@gmail.com>
