### PR TITLE
fix: support mirrored/proxied registry images in image ref parsing

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -201,6 +201,7 @@ def _split_image(image):
     tag = ""
     if "@" in image:
         image, digest = image.split("@", 1)
+
     # Split tags only on the last ':' after the last '/'. This avoids treating
     # registry ports (for example mirror.local:5000/...) as image tags.
     last_colon = image.rfind(":")

--- a/rules.bzl
+++ b/rules.bzl
@@ -201,14 +201,13 @@ def _split_image(image):
     tag = ""
     if "@" in image:
         image, digest = image.split("@", 1)
-    else:
-        # Split tags only on the last ':' after the last '/'. This avoids treating
-        # registry ports (for example mirror.local:5000/...) as image tags.
-        last_colon = image.rfind(":")
-        last_slash = image.rfind("/")
-        if last_colon > last_slash:
-            tag = image[last_colon + 1:]
-            image = image[:last_colon]
+    # Split tags only on the last ':' after the last '/'. This avoids treating
+    # registry ports (for example mirror.local:5000/...) as image tags.
+    last_colon = image.rfind(":")
+    last_slash = image.rfind("/")
+    if last_colon > last_slash:
+        tag = image[last_colon + 1:]
+        image = image[:last_colon]
 
     return image, tag, digest
 

--- a/rules.bzl
+++ b/rules.bzl
@@ -189,7 +189,9 @@ def _is_same_repository(a, b):
     repo_a, _, _ = _split_image(a)
     repo_b, _, _ = _split_image(b)
 
-    return repo_a == repo_b
+    # Allow mirrored images where the upstream repository is prefixed by a registry/cache path.
+    # Example: mirror.local:5000/gcr.io/flame-public/rbe-ubuntu22-04
+    return repo_a == repo_b or repo_a.endswith("/" + repo_b)
 
 def _split_image(image):
     if image.startswith("docker://"):
@@ -198,9 +200,15 @@ def _split_image(image):
     digest = ""
     tag = ""
     if "@" in image:
-        image, digest = image.split("@")
-    elif ":" in image:
-        image, tag = image.split(":")
+        image, digest = image.split("@", 1)
+    else:
+        # Split tags only on the last ':' after the last '/'. This avoids treating
+        # registry ports (for example mirror.local:5000/...) as image tags.
+        last_colon = image.rfind(":")
+        last_slash = image.rfind("/")
+        if last_colon > last_slash:
+            tag = image[last_colon + 1:]
+            image = image[:last_colon]
 
     return image, tag, digest
 


### PR DESCRIPTION
## Problem

`_split_image` and `_is_same_repository` in `rules.bzl` break when Docker images are served through a pull-through registry cache / mirror whose URL includes a port number, such as:

```
mirror.local:5000/gcr.io/flame-public/rbe-ubuntu22-04:latest
```

Two bugs:

1. **`_split_image`** splits on the first `:` it finds, so `mirror.local:5000/...` is parsed as `image = "mirror.local"`, `tag = "5000/..."` — completely wrong.
2. **`_is_same_repository`** uses strict equality, so the mirrored URL never matches the canonical upstream URL, causing toolchain resolution to fail even when the image content is identical.

## Fix

### `_split_image`
Use `rfind(":")` and `rfind("/")` to locate the tag separator: the tag colon must come *after* the last `/`. This correctly handles `registry:port/image:tag` and `registry:port/image` (no tag). Also switched the digest split to `split("@", 1)` for safety.

### `_is_same_repository`  
Accept a mirrored image as "the same repository" when the mirror path ends with `"/" + upstream_repo`. For example:

```
mirror.local:5000/gcr.io/flame-public/rbe-ubuntu22-04
gcr.io/flame-public/rbe-ubuntu22-04
```

are now considered the same repository.

## Testing

Verified locally against a Bazel workspace that uses a pull-through registry cache (`mirror.local:5000/...`) as the `exec_properties` container image. Before this fix, the build failed with a toolchain resolution error; after, it succeeds.